### PR TITLE
Color preview

### DIFF
--- a/src/main/kotlin/com/varabyte/kobweb/intellij/colors/KobwebColorProvider.kt
+++ b/src/main/kotlin/com/varabyte/kobweb/intellij/colors/KobwebColorProvider.kt
@@ -133,7 +133,8 @@ private fun KtSimpleNameExpression.findDeclaration(): PsiElement? = this.mainRef
  * Evaluates a collection of value arguments to the specified type.
  *
  * For example, if we have a collection of decimal, hex, and binary arguments,
- * this method can parse them into regular integer values.
+ * this method can parse them into regular integer values, so 123, 0x7B and 0b0111_1011
+ * would all evaluate to 123.
  *
  * @return the evaluated arguments if evaluation of **all** arguments succeeded, otherwise null
  */

--- a/src/main/kotlin/com/varabyte/kobweb/intellij/colors/KobwebColorProvider.kt
+++ b/src/main/kotlin/com/varabyte/kobweb/intellij/colors/KobwebColorProvider.kt
@@ -48,7 +48,7 @@ private fun traceColor(element: PsiElement, currentDepth: Int = 0): Color? {
 
         is KtNameReferenceExpression -> when {
             element.parent is KtCallExpression -> element.parent // Element is name of a function
-            else -> element.locateSource()
+            else -> element.findDeclaration()
         }
 
         is KtProperty -> when {
@@ -60,7 +60,7 @@ private fun traceColor(element: PsiElement, currentDepth: Int = 0): Color? {
         is KtPropertyAccessor -> element.bodyExpression
 
         is KtCallExpression -> (null).apply {
-            val callee = ((element.calleeExpression as? KtNameReferenceExpression)?.locateSource() as? KtNamedFunction)
+            val callee = ((element.calleeExpression as? KtNameReferenceExpression)?.findDeclaration() as? KtNamedFunction)
                 ?: return@apply
 
             when {
@@ -110,7 +110,7 @@ private fun traceColor(element: PsiElement, currentDepth: Int = 0): Color? {
 
 // navigationElement returns the element where a feature like "Go to declaration" would point:
 // The source declaration, if found, and not a compiled one, which would make further analyzing impossible.
-private fun KtSimpleNameExpression.locateSource(): PsiElement? = this.mainReference.resolve()?.navigationElement
+private fun KtSimpleNameExpression.findDeclaration(): PsiElement? = this.mainReference.resolve()?.navigationElement
 
 /**
  * Uses the kotlin analysis api, as it can parse the constants much smarter.

--- a/src/main/kotlin/com/varabyte/kobweb/intellij/colors/KobwebColorProvider.kt
+++ b/src/main/kotlin/com/varabyte/kobweb/intellij/colors/KobwebColorProvider.kt
@@ -1,0 +1,120 @@
+package com.varabyte.kobweb.intellij.colors
+
+import com.intellij.ide.util.PsiNavigationSupport
+import com.intellij.openapi.editor.ElementColorProvider
+import com.intellij.openapi.fileEditor.OpenFileDescriptor
+import com.intellij.psi.PsiElement
+import com.intellij.psi.impl.source.tree.LeafPsiElement
+import com.intellij.psi.util.PsiUtilBase
+import org.jetbrains.kotlin.analysis.api.analyze
+import org.jetbrains.kotlin.analysis.api.components.KtConstantEvaluationMode
+import org.jetbrains.kotlin.idea.base.psi.kotlinFqName
+import org.jetbrains.kotlin.idea.core.util.toPsiFile
+import org.jetbrains.kotlin.idea.references.mainReference
+import org.jetbrains.kotlin.js.translate.declaration.hasCustomGetter
+import org.jetbrains.kotlin.lexer.KtTokens
+import org.jetbrains.kotlin.psi.*
+import java.awt.Color
+
+private const val KOBWEB_COLOR_COMPANION_FQ_NAME = "com.varabyte.kobweb.compose.ui.graphics.Color.Companion"
+
+/**
+ * Enables showing those small rectangular color previews next to the line number
+ */
+class KobwebColorProvider : ElementColorProvider {
+
+    override fun getColorFrom(element: PsiElement): Color? = when {
+        element !is LeafPsiElement -> null
+        element.elementType != KtTokens.IDENTIFIER -> null
+        element.parent is KtProperty -> null // Avoid showing multiple previews
+        else -> traceColor(element.parent) // Identifier is just text. The parent is the actual object
+    }
+
+    /**
+     * Setting colors is not (yet) supported
+     */
+    override fun setColorTo(element: PsiElement, color: Color) = Unit
+}
+
+/**
+ * Tries resolving references as deep as possible and checks if a Kobweb color is being referred to
+ */
+private fun traceColor(element: PsiElement): Color? {
+    val nextElement = when (element) {
+        is KtDotQualifiedExpression -> element.selectorExpression
+
+        is KtNameReferenceExpression -> when {
+            element.parent is KtCallExpression -> element.parent // Element is name of a function
+            else -> element.locateSource()
+        }
+
+        is KtProperty -> when {
+            element.hasInitializer() -> element.initializer
+            element.hasCustomGetter() -> element.getter
+            else -> null
+        }
+
+        is KtPropertyAccessor -> element.bodyExpression
+
+        is KtCallExpression -> (null).apply {
+            val callee = ((element.calleeExpression as? KtNameReferenceExpression)?.locateSource() as? KtNamedFunction)
+                ?: return@apply
+
+            when {
+                callee.isKobwebColorFunction("rgb(r: Int, g: Int, b: Int)") -> run {
+                    val args = element.valueArguments.evaluateArguments<Int>() ?: return@run
+                    return safeRgbColor(args[0], args[1], args[2])
+                }
+            }
+        }
+
+        else -> null
+    }
+
+    return nextElement?.let { traceColor(it) }
+}
+
+/**
+ * Pretty much emulates what CTRL-clicking on a reference would do
+ */
+private fun KtSimpleNameExpression.locateSource(): PsiElement? {
+    val resolvedMainReference = this.mainReference.resolve() ?: return null
+    val sourceDescriptor =
+        PsiNavigationSupport.getInstance().getDescriptor(resolvedMainReference) as? OpenFileDescriptor ?: return null
+    val sourcePsiFile = sourceDescriptor.file.toPsiFile(this.project) ?: return null
+    val sourceElementIdentifier = PsiUtilBase.getElementAtOffset(sourcePsiFile, sourceDescriptor.offset)
+    val sourceElement = sourceElementIdentifier.parent
+
+    return sourceElement
+}
+
+/**
+ * Uses the kotlin analysis api, as it can parse the constants much smarter.
+ * It can parse decimal, hex and binary automatically for example.
+ */
+private inline fun <reified T> Collection<KtValueArgument>.evaluateArguments(): Array<T>? {
+    val constantExpressions = this.mapNotNull { it.getArgumentExpression() as? KtConstantExpression }
+
+    val evaluatedArguments = constantExpressions.mapNotNull {
+        analyze(it.containingKtFile) {
+            it.evaluate(KtConstantEvaluationMode.CONSTANT_LIKE_EXPRESSION_EVALUATION)?.value as? T
+        }
+    }
+
+    return if (evaluatedArguments.size != this.size) null
+    else evaluatedArguments.toTypedArray()
+}
+
+private fun KtNamedFunction.isKobwebColorFunction(functionSignature: String): Boolean {
+    val actualFqName = this.kotlinFqName?.asString() ?: return false
+    val actualParameters = this.valueParameterList?.text ?: return false
+
+    val expected = "$KOBWEB_COLOR_COMPANION_FQ_NAME.$functionSignature"
+    val actual = actualFqName + actualParameters
+
+    return expected == actual
+}
+
+@Suppress("UseJBColor")
+private fun safeRgbColor(r: Int, g: Int, b: Int) =
+    runCatching { Color(r, g, b) }.getOrNull()

--- a/src/main/kotlin/com/varabyte/kobweb/intellij/colors/KobwebColorProvider.kt
+++ b/src/main/kotlin/com/varabyte/kobweb/intellij/colors/KobwebColorProvider.kt
@@ -136,7 +136,11 @@ private fun KtSimpleNameExpression.findDeclaration(): PsiElement? = this.mainRef
  * this method can parse them into regular integer values, so 123, 0x7B and 0b0111_1011
  * would all evaluate to 123.
  *
- * @return the evaluated arguments if evaluation of **all** arguments succeeded, otherwise null
+ * @param argCount The size the original and evaluated collections must have
+ * @param evaluatedValueMapper Convenience parameter to avoid having to type `.map { ... }.toTypedArray()`
+ *
+ * @return the evaluated arguments of length [argCount] if evaluation of **all** arguments succeeded,
+ * and [argCount] elements were passed for evaluation, otherwise null
  */
 private inline fun <reified Evaluated, reified Mapped> Collection<KtValueArgument>.evaluateArguments(
     argCount: Int,

--- a/src/main/kotlin/com/varabyte/kobweb/intellij/colors/KobwebColorProvider.kt
+++ b/src/main/kotlin/com/varabyte/kobweb/intellij/colors/KobwebColorProvider.kt
@@ -52,7 +52,12 @@ class KobwebColorProvider : ElementColorProvider {
 }
 
 /**
- * Tries resolving references as deep as possible and checks if a Kobweb color is being referred to
+ * Tries resolving references as deep as possible and checks if a Kobweb color is being referred to.
+ *
+ * @return the color being referenced, or null if the [element] ultimately doesn't resolve to
+ * a color at all (which is common) or if the amount of times we'd have to follow references to get to the color
+ * is too many, or it *was* a color but not one we could extract specific information
+ * about (e.g. a method that returns one of two colors based on a condition).
  */
 private fun traceColor(element: PsiElement, currentDepth: Int = 0): Color? {
     val nextElement = when (element) {

--- a/src/main/kotlin/com/varabyte/kobweb/intellij/colors/KobwebColorProvider.kt
+++ b/src/main/kotlin/com/varabyte/kobweb/intellij/colors/KobwebColorProvider.kt
@@ -108,32 +108,32 @@ private fun tryParseKobwebColorFunctionCall(
     when {
         callee.isKobwebColorFunction("rgb(r: Int, g: Int, b: Int)") ->
             evaluateArguments<Int>(3)?.let { args ->
-                safeRgbColor(args[0], args[1], args[2])
+                tryCreateRgbColor(args[0], args[1], args[2])
             }
 
         callee.isKobwebColorFunction("rgb(value: Int)") ->
             evaluateArguments<Int>(1)?.let { args ->
-                safeRgbColor(args[0])
+                tryCreateRgbColor(args[0])
             }
 
         callee.isKobwebColorFunction("rgba(value: Int)", "rgba(value: Long)") ->
             (evaluateArguments<Int>(1) ?: evaluateArguments<Long, Int>(1) { it.toInt() })?.let { args ->
-                safeRgbColor(args[0] shr Byte.SIZE_BITS)
+                tryCreateRgbColor(args[0] shr Byte.SIZE_BITS)
             }
 
         callee.isKobwebColorFunction("argb(value: Int)", "argb(value: Long)") ->
             (evaluateArguments<Int>(1) ?: evaluateArguments<Long, Int>(1) { it.toInt() })?.let { args ->
-                safeRgbColor(args[0] and 0x00_FF_FF_FF)
+                tryCreateRgbColor(args[0] and 0x00_FF_FF_FF)
             }
 
         callee.isKobwebColorFunction("hsl(h: Float, s: Float, l: Float)") ->
             evaluateArguments<Float>(3)?.let { args ->
-                safeHslColor(args[0], args[1], args[2])
+                tryCreateHslColor(args[0], args[1], args[2])
             }
 
         callee.isKobwebColorFunction("hsla(h: Float, s: Float, l: Float, a: Float)") ->
             evaluateArguments<Float>(4)?.let { args ->
-                safeHslColor(args[0], args[1], args[2])
+                tryCreateHslColor(args[0], args[1], args[2])
             }
 
         else -> null
@@ -190,13 +190,13 @@ private fun KtNamedFunction.isKobwebColorFunction(vararg functionSignatures: Str
     }
 }
 
-private fun safeRgbColor(r: Int, g: Int, b: Int) =
+private fun tryCreateRgbColor(r: Int, g: Int, b: Int) =
     runCatching { Color(r, g, b) }.getOrNull()
 
-private fun safeRgbColor(rgb: Int) =
+private fun tryCreateRgbColor(rgb: Int) =
     runCatching { Color(rgb) }.getOrNull()
 
-private fun safeHslColor(hue: Float, saturation: Float, lightness: Float): Color? {
+private fun tryCreateHslColor(hue: Float, saturation: Float, lightness: Float): Color? {
     // https://en.wikipedia.org/wiki/HSL_and_HSV#Color_conversion_formulae
     val chroma = (1 - abs(2 * lightness - 1)) * saturation
     val intermediateValue = chroma * (1 - abs(((hue / 60) % 2) - 1))
@@ -244,7 +244,7 @@ private fun safeHslColor(hue: Float, saturation: Float, lightness: Float): Color
     }
     val lightnessAdjustment = lightness - chroma / 2
 
-    return safeRgbColor(
+    return tryCreateRgbColor(
         ((r + lightnessAdjustment) * 255f).toInt(),
         ((g + lightnessAdjustment) * 255f).toInt(),
         ((b + lightnessAdjustment) * 255f).toInt()

--- a/src/main/kotlin/com/varabyte/kobweb/intellij/colors/KobwebColorProvider.kt
+++ b/src/main/kotlin/com/varabyte/kobweb/intellij/colors/KobwebColorProvider.kt
@@ -1,3 +1,4 @@
+// ElementColorProvider interface uses standard AWT Color, as no darkened version is needed
 @file:Suppress("UseJBColor")
 
 package com.varabyte.kobweb.intellij.colors

--- a/src/main/kotlin/com/varabyte/kobweb/intellij/colors/KobwebColorProvider.kt
+++ b/src/main/kotlin/com/varabyte/kobweb/intellij/colors/KobwebColorProvider.kt
@@ -2,16 +2,12 @@
 
 package com.varabyte.kobweb.intellij.colors
 
-import com.intellij.ide.util.PsiNavigationSupport
 import com.intellij.openapi.editor.ElementColorProvider
-import com.intellij.openapi.fileEditor.OpenFileDescriptor
 import com.intellij.psi.PsiElement
 import com.intellij.psi.impl.source.tree.LeafPsiElement
-import com.intellij.psi.util.PsiUtilBase
 import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.analysis.api.components.KtConstantEvaluationMode
 import org.jetbrains.kotlin.idea.base.psi.kotlinFqName
-import org.jetbrains.kotlin.idea.core.util.toPsiFile
 import org.jetbrains.kotlin.idea.references.mainReference
 import org.jetbrains.kotlin.js.translate.declaration.hasCustomGetter
 import org.jetbrains.kotlin.lexer.KtTokens
@@ -112,19 +108,9 @@ private fun traceColor(element: PsiElement, currentDepth: Int = 0): Color? {
     } else null
 }
 
-/**
- * Pretty much emulates what CTRL-clicking on a reference would do
- */
-private fun KtSimpleNameExpression.locateSource(): PsiElement? {
-    val resolvedMainReference = this.mainReference.resolve() ?: return null
-    val sourceDescriptor =
-        PsiNavigationSupport.getInstance().getDescriptor(resolvedMainReference) as? OpenFileDescriptor ?: return null
-    val sourcePsiFile = sourceDescriptor.file.toPsiFile(this.project) ?: return null
-    val sourceElementIdentifier = PsiUtilBase.getElementAtOffset(sourcePsiFile, sourceDescriptor.offset)
-    val sourceElement = sourceElementIdentifier.parent
-
-    return sourceElement
-}
+// navigationElement returns the element where a feature like "Go to declaration" would point:
+// The source declaration, if found, and not a compiled one, which would make further analyzing impossible.
+private fun KtSimpleNameExpression.locateSource(): PsiElement? = this.mainReference.resolve()?.navigationElement
 
 /**
  * Uses the kotlin analysis api, as it can parse the constants much smarter.

--- a/src/main/kotlin/com/varabyte/kobweb/intellij/colors/KobwebColorProvider.kt
+++ b/src/main/kotlin/com/varabyte/kobweb/intellij/colors/KobwebColorProvider.kt
@@ -66,7 +66,7 @@ private fun traceColor(element: PsiElement, currentDepth: Int = 0): Color? {
 
             when {
                 callee.isKobwebColorFunction("rgb(r: Int, g: Int, b: Int)") -> run {
-                    val args = element.valueArguments.evaluateArguments<Int>() ?: return@run
+                    val args = element.valueArguments.evaluateArguments<Int>(3) ?: return@run
                     return safeRgbColor(args[0], args[1], args[2])
                 }
             }
@@ -98,7 +98,7 @@ private fun KtSimpleNameExpression.locateSource(): PsiElement? {
  * Uses the kotlin analysis api, as it can parse the constants much smarter.
  * It can parse decimal, hex and binary automatically for example.
  */
-private inline fun <reified T> Collection<KtValueArgument>.evaluateArguments(): Array<T>? {
+private inline fun <reified T> Collection<KtValueArgument>.evaluateArguments(argCount: Int): Array<T>? {
     val constantExpressions = this.mapNotNull { it.getArgumentExpression() as? KtConstantExpression }
 
     val evaluatedArguments = constantExpressions.mapNotNull {
@@ -107,7 +107,7 @@ private inline fun <reified T> Collection<KtValueArgument>.evaluateArguments(): 
         }
     }
 
-    return if (evaluatedArguments.size != this.size) null
+    return if (evaluatedArguments.size != this.size || evaluatedArguments.size != argCount) null
     else evaluatedArguments.toTypedArray()
 }
 

--- a/src/main/kotlin/com/varabyte/kobweb/intellij/colors/KobwebColorProvider.kt
+++ b/src/main/kotlin/com/varabyte/kobweb/intellij/colors/KobwebColorProvider.kt
@@ -111,14 +111,15 @@ private inline fun <reified T> Collection<KtValueArgument>.evaluateArguments(arg
     else evaluatedArguments.toTypedArray()
 }
 
-private fun KtNamedFunction.isKobwebColorFunction(functionSignature: String): Boolean {
+private fun KtNamedFunction.isKobwebColorFunction(vararg functionSignatures: String): Boolean {
     val actualFqName = this.kotlinFqName?.asString() ?: return false
     val actualParameters = this.valueParameterList?.text ?: return false
-
-    val expected = "$KOBWEB_COLOR_COMPANION_FQ_NAME.$functionSignature"
     val actual = actualFqName + actualParameters
 
-    return expected == actual
+    return functionSignatures.any { functionSignature ->
+        val expected = "$KOBWEB_COLOR_COMPANION_FQ_NAME.$functionSignature"
+        expected == actual
+    }
 }
 
 @Suppress("UseJBColor")

--- a/src/main/kotlin/com/varabyte/kobweb/intellij/colors/KobwebColorProvider.kt
+++ b/src/main/kotlin/com/varabyte/kobweb/intellij/colors/KobwebColorProvider.kt
@@ -73,7 +73,7 @@ private fun traceColor(element: PsiElement, currentDepth: Int = 0): Color? {
                 }
 
                 callee.isKobwebColorFunction("rgb(value: Int)") -> run {
-                    val args = element.valueArguments.run { evaluateArguments<Int>(1) } ?: return@run
+                    val args = element.valueArguments.evaluateArguments<Int>(1) ?: return@run
                     return safeRgbColor(args[0])
                 }
 

--- a/src/main/kotlin/com/varabyte/kobweb/intellij/colors/KobwebColorProvider.kt
+++ b/src/main/kotlin/com/varabyte/kobweb/intellij/colors/KobwebColorProvider.kt
@@ -142,6 +142,8 @@ private inline fun <reified Evaluated, reified Mapped> Collection<KtValueArgumen
     argCount: Int,
     evaluatedValueMapper: (Evaluated) -> Mapped
 ): Array<Mapped>? {
+    if (this.size != argCount) return null
+
     val constantExpressions = this.mapNotNull { it.getArgumentExpression() as? KtConstantExpression }
 
     val evaluatedArguments = constantExpressions.mapNotNull {
@@ -150,7 +152,7 @@ private inline fun <reified Evaluated, reified Mapped> Collection<KtValueArgumen
         }
     }
 
-    return if (evaluatedArguments.size != this.size || evaluatedArguments.size != argCount) null
+    return if (evaluatedArguments.size != argCount) null
     else evaluatedArguments.map(evaluatedValueMapper).toTypedArray()
 }
 

--- a/src/main/kotlin/com/varabyte/kobweb/intellij/colors/KobwebColorProvider.kt
+++ b/src/main/kotlin/com/varabyte/kobweb/intellij/colors/KobwebColorProvider.kt
@@ -16,8 +16,19 @@ import org.jetbrains.kotlin.psi.*
 import java.awt.Color
 import kotlin.math.abs
 
-// This prevents the color tracer from checking the codebase ridiculously deep,
-// which might cause lag or even worse a stackoverflow
+/*
+This prevents the color tracer from following references ridiculously deep into the codebase.
+If a method ultimately returns a color, it's unlikely that it will involve *that* many jumps to fetch it.
+Testing showed, that a search depth of 15 allows finding a result 3-4 references deep.
+If we don't limit, we could possibly get stuck chasing a cyclical loop. Also, high limits
+may increase memory usage because we have to chase down every method we come across as possibly returning a color.
+Unlimited search depth might also introduce lag or, in the case of a cycle, a stack overflow.
+Note that Android Studio sets their depth a bit higher than we do. (See https://cs.android.com/android-studio/platform/tools/base/+/mirror-goog-studio-main:sdk-common/src/main/java/com/android/ide/common/resources/ResourceResolver.java;l=67?q=MAX_RESOURCE_INDIRECTION)
+However they also appear to do their tracing of colors differently.
+If there are reports in the wild about color preview not working, we can consider increasing this value at that time,
+though it is likely caused by their specific color function not being supported
+or the tracing algorithm being unable to analyze more complex code correctly.
+*/
 private const val MAX_SEARCH_DEPTH = 15
 
 private const val KOBWEB_COLOR_COMPANION_FQ_NAME = "com.varabyte.kobweb.compose.ui.graphics.Color.Companion"

--- a/src/main/kotlin/com/varabyte/kobweb/intellij/colors/KobwebColorProvider.kt
+++ b/src/main/kotlin/com/varabyte/kobweb/intellij/colors/KobwebColorProvider.kt
@@ -130,8 +130,12 @@ private fun traceColor(element: PsiElement, currentDepth: Int = 0): Color? {
 private fun KtSimpleNameExpression.findDeclaration(): PsiElement? = this.mainReference.resolve()?.navigationElement
 
 /**
- * Uses the kotlin analysis api, as it can parse the constants much smarter.
- * It can parse decimal, hex and binary automatically for example.
+ * Evaluates a collection of value arguments to the specified type.
+ *
+ * For example, if we have a collection of decimal, hex, and binary arguments,
+ * this method can parse them into regular integer values.
+ *
+ * @return the evaluated arguments if evaluation of **all** arguments succeeded, otherwise null
  */
 private inline fun <reified Evaluated, reified Mapped> Collection<KtValueArgument>.evaluateArguments(
     argCount: Int,

--- a/src/main/kotlin/com/varabyte/kobweb/intellij/colors/KobwebColorProvider.kt
+++ b/src/main/kotlin/com/varabyte/kobweb/intellij/colors/KobwebColorProvider.kt
@@ -34,7 +34,7 @@ private const val MAX_SEARCH_DEPTH = 15
 private const val KOBWEB_COLOR_COMPANION_FQ_NAME = "com.varabyte.kobweb.compose.ui.graphics.Color.Companion"
 
 /**
- * Enables showing those small rectangular color previews next to the line number
+ * Enables showing small rectangular gutter icons that preview Kobweb colors
  */
 class KobwebColorProvider : ElementColorProvider {
 

--- a/src/main/kotlin/com/varabyte/kobweb/intellij/colors/KobwebColorProvider.kt
+++ b/src/main/kotlin/com/varabyte/kobweb/intellij/colors/KobwebColorProvider.kt
@@ -60,8 +60,8 @@ private fun traceColor(element: PsiElement, currentDepth: Int = 0): Color? {
         is KtPropertyAccessor -> element.bodyExpression
 
         is KtCallExpression -> (null).apply {
-            val callee = ((element.calleeExpression as? KtNameReferenceExpression)?.findDeclaration() as? KtNamedFunction)
-                ?: return@apply
+            val calleeExpression = element.calleeExpression as? KtNameReferenceExpression ?: return@apply
+            val callee = calleeExpression.findDeclaration() as? KtNamedFunction ?: return@apply
 
             when {
                 callee.isKobwebColorFunction("rgb(r: Int, g: Int, b: Int)") -> run {

--- a/src/main/kotlin/com/varabyte/kobweb/intellij/colors/KobwebColorProvider.kt
+++ b/src/main/kotlin/com/varabyte/kobweb/intellij/colors/KobwebColorProvider.kt
@@ -27,7 +27,7 @@ class KobwebColorProvider : ElementColorProvider {
         element !is LeafPsiElement -> null
         element.elementType != KtTokens.IDENTIFIER -> null
         element.parent is KtProperty -> null // Avoid showing multiple previews
-        else -> traceColor(element.parent) // Identifier is just text. The parent is the actual object
+        else -> traceColor(element.parent) // Leaf is just text. The parent is the actual object
     }
 
     /**

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -27,5 +27,7 @@
     <extensions defaultExtensionNs="com.intellij">
         <lang.inspectionSuppressor language="kotlin" implementationClass="com.varabyte.kobweb.intellij.inspections.FunctionNameInspectionSuppressor"/>
         <lang.inspectionSuppressor language="kotlin" implementationClass="com.varabyte.kobweb.intellij.inspections.UnusedInspectionSuppressor"/>
+
+        <colorProvider implementation="com.varabyte.kobweb.intellij.colors.KobwebColorProvider" />
     </extensions>
 </idea-plugin>


### PR DESCRIPTION
Closes #6 

![image](https://github.com/varabyte/kobweb-intellij-plugin/assets/54677650/5b914240-f7bc-41ae-b0e9-3946c9fac5c4)

Adds small rectangles next to the line number that preview kobweb colors.

TODO:
- [x] Support more color creation functions