### PR TITLE
Add a way to detect if a PsiElement belongs to a Kobweb Project

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,9 +8,15 @@ version = libs.versions.kobweb.ide.plugin.get()
 
 repositories {
     mavenCentral()
+    // For Gradle tooling API
+    maven("https://repo.gradle.org/gradle/libs-releases")
 }
 
 dependencies {
+    // For Gradle Tooling API (used for querying information from gradle projects))
+    implementation("org.gradle:gradle-tooling-api:${gradle.gradleVersion}")
+    runtimeOnly("org.slf4j:slf4j-nop:2.0.11") // Needed by gradle tooling
+
     testImplementation(libs.truthish)
 }
 
@@ -21,7 +27,8 @@ intellij {
     type.set("IC") // Target IDE Platform
 
     plugins.set(listOf(
-        "org.jetbrains.kotlin"
+        "org.jetbrains.kotlin",
+        "org.jetbrains.plugins.gradle",
     ))
 }
 

--- a/src/main/kotlin/com/varabyte/kobweb/intellij/colors/KobwebColorProvider.kt
+++ b/src/main/kotlin/com/varabyte/kobweb/intellij/colors/KobwebColorProvider.kt
@@ -6,6 +6,7 @@ package com.varabyte.kobweb.intellij.colors
 import com.intellij.openapi.editor.ElementColorProvider
 import com.intellij.psi.PsiElement
 import com.intellij.psi.impl.source.tree.LeafPsiElement
+import com.varabyte.kobweb.intellij.util.kobweb.isInKobwebReadContext
 import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.analysis.api.components.KtConstantEvaluationMode
 import org.jetbrains.kotlin.idea.base.psi.kotlinFqName
@@ -42,6 +43,7 @@ class KobwebColorProvider : ElementColorProvider {
         element !is LeafPsiElement -> null
         element.elementType != KtTokens.IDENTIFIER -> null
         element.parent is KtProperty -> null // Avoid showing multiple previews
+        !element.isInKobwebReadContext() -> null
         else -> traceColor(element.parent) // Leaf is just text. The parent is the actual object
     }
 

--- a/src/main/kotlin/com/varabyte/kobweb/intellij/inspections/FunctionNameInspectionSuppressor.kt
+++ b/src/main/kotlin/com/varabyte/kobweb/intellij/inspections/FunctionNameInspectionSuppressor.kt
@@ -3,6 +3,7 @@ package com.varabyte.kobweb.intellij.inspections
 import com.intellij.codeInspection.InspectionSuppressor
 import com.intellij.codeInspection.SuppressQuickFix
 import com.intellij.psi.PsiElement
+import com.varabyte.kobweb.intellij.util.kobweb.isInKobwebReadContext
 import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.analysis.api.annotations.annotationClassIds
 import org.jetbrains.kotlin.psi.KtNamedFunction
@@ -17,6 +18,7 @@ private val SUPPRESS_FUNCTION_NAME_WHEN_ANNOTATED_WITH = arrayOf(
 class FunctionNameInspectionSuppressor : InspectionSuppressor {
     override fun isSuppressedFor(element: PsiElement, toolId: String): Boolean {
         if (toolId != "FunctionName") return false
+        if (!element.isInKobwebReadContext()) return false
         val ktFunction = element.parent as? KtNamedFunction ?: return false
 
         analyze(ktFunction) {

--- a/src/main/kotlin/com/varabyte/kobweb/intellij/inspections/UnusedInspectionSuppressor.kt
+++ b/src/main/kotlin/com/varabyte/kobweb/intellij/inspections/UnusedInspectionSuppressor.kt
@@ -3,6 +3,7 @@ package com.varabyte.kobweb.intellij.inspections
 import com.intellij.codeInspection.InspectionSuppressor
 import com.intellij.codeInspection.SuppressQuickFix
 import com.intellij.psi.PsiElement
+import com.varabyte.kobweb.intellij.util.kobweb.isInKobwebReadContext
 import org.jetbrains.kotlin.analysis.api.analyze
 import org.jetbrains.kotlin.analysis.api.annotations.annotationClassIds
 import org.jetbrains.kotlin.psi.KtNamedFunction
@@ -22,6 +23,7 @@ private val SUPPRESS_UNUSED_WHEN_ANNOTATED_WITH = arrayOf(
 class UnusedInspectionSuppressor : InspectionSuppressor {
     override fun isSuppressedFor(element: PsiElement, toolId: String): Boolean {
         if (toolId != "unused") return false
+        if (!element.isInKobwebReadContext()) return false
         val ktFunction = element.parent as? KtNamedFunction ?: return false
 
         analyze(ktFunction) {

--- a/src/main/kotlin/com/varabyte/kobweb/intellij/project/KobwebProject.kt
+++ b/src/main/kotlin/com/varabyte/kobweb/intellij/project/KobwebProject.kt
@@ -1,0 +1,89 @@
+package com.varabyte.kobweb.intellij.project
+
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.vfs.VirtualFile
+import com.varabyte.kobweb.intellij.util.kobweb.isInKobwebReadContext
+import com.varabyte.kobweb.intellij.util.kobweb.isInKobwebWriteContext
+
+/**
+ * A Kobweb Project is a module that has applied one of the Kobweb Gradle Plugins.
+ *
+ * It can either be a local project inside the user's workspace or an external dependency (e.g. a maven artifact).
+ */
+class KobwebProject(
+    val name: String,
+    val type: Type,
+    val source: Source,
+) {
+    enum class Type {
+        Application,
+        Library,
+        Worker,
+    }
+
+    /**
+     * A collection of useful sets of [Type]s.
+     *
+     * These can be useful to pass into the [isInKobwebReadContext] and [isInKobwebWriteContext] extension methods.
+     */
+    object Types {
+        /**
+         * The set of all Kobweb project types.
+         */
+        val All = Type.entries.toSet()
+
+        /**
+         * The set of core Kobweb project types that affect the frontend DOM / backend API routes.
+         */
+        val Framework = setOf(Type.Application, Type.Library)
+
+        val WorkerOnly = setOf(Type.Worker)
+    }
+
+    /**
+     * Where the code for this Kobweb project lives, i.e. in the user's project or as an external dependency.
+     */
+    sealed class Source {
+        /**
+         * The code for this Kobweb project lives in the user's project somewhere.
+         *
+         * This should be considered editable code, and refactoring actions should be available.
+         */
+        class Local(val module: Module) : Source()
+
+        /**
+         * The code for this Kobweb project lives in an external dependency (e.g. a maven artifact).
+         *
+         * This should be considered read-only code, and refactoring actions should not be available.
+         */
+        class External(val jar: VirtualFile) : Source()
+
+        override fun equals(other: Any?): Boolean {
+            if (other !is Source) return false
+            return when {
+                this is Local && other is Local -> this.module == other.module
+                this is External && other is External -> this.jar == other.jar
+                else -> false
+            }
+        }
+
+        override fun hashCode(): Int {
+            return when(this) {
+                is Local -> module.hashCode()
+                is External -> jar.hashCode()
+            }
+        }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        return other is KobwebProject && this.source == other.source
+    }
+
+    override fun hashCode(): Int {
+        return source.hashCode()
+    }
+
+    override fun toString(): String {
+        return "KobwebProject(name='$name', type=$type, source=${source::class.simpleName})"
+    }
+}

--- a/src/main/kotlin/com/varabyte/kobweb/intellij/services/project/KobwebProjectCacheService.kt
+++ b/src/main/kotlin/com/varabyte/kobweb/intellij/services/project/KobwebProjectCacheService.kt
@@ -1,0 +1,54 @@
+package com.varabyte.kobweb.intellij.services.project
+
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.vfs.VirtualFile
+import com.varabyte.kobweb.intellij.project.KobwebProject
+import java.util.*
+
+/**
+ * A project service which can be queried to find all Kobweb projects in the current workspace.
+ *
+ * Knowing if you're inside a Kobweb project can be useful before running an inspection or action, so that we don't
+ * waste time processing code that isn't relevant to Kobweb (e.g. if we're in a multiplatform project with Kobweb,
+ * Android, and other types of modules).
+ *
+ * @see KobwebProject
+ */
+interface KobwebProjectCacheService : Iterable<KobwebProject> {
+    operator fun get(module: Module): KobwebProject?
+    operator fun get(jar: VirtualFile): KobwebProject?
+    fun add(project: KobwebProject)
+    fun addAll(collection: Collection<KobwebProject>)
+    fun removeIf(filter: (KobwebProject) -> Boolean)
+}
+
+private class KobwebProjectCacheServiceImpl : KobwebProjectCacheService {
+    private val localProjects = Collections.synchronizedMap(mutableMapOf<Module, KobwebProject>())
+    private val externalProjects = Collections.synchronizedMap(mutableMapOf<VirtualFile, KobwebProject>())
+
+    override operator fun get(module: Module) = localProjects[module]
+    override operator fun get(jar: VirtualFile) = externalProjects[jar]
+    override fun add(project: KobwebProject) {
+        when (project.source) {
+            is KobwebProject.Source.External -> externalProjects[project.source.jar] = project
+            is KobwebProject.Source.Local -> localProjects[project.source.module] = project
+        }
+    }
+
+    override fun addAll(collection: Collection<KobwebProject>) {
+        collection.forEach { add(it) }
+    }
+
+    override fun removeIf(filter: (KobwebProject) -> Boolean) {
+        externalProjects.values.removeIf(filter)
+        localProjects.values.removeIf(filter)
+    }
+
+    override fun iterator(): Iterator<KobwebProject> {
+        return (localProjects.values + externalProjects.values).iterator()
+    }
+
+    override fun toString(): String {
+        return "KobwebProjects${this.iterator().asSequence().joinToString(prefix = "[", postfix = "]") { it.name }}"
+    }
+}

--- a/src/main/kotlin/com/varabyte/kobweb/intellij/startup/DiscoverKobwebProjectsProjectActivity.kt
+++ b/src/main/kotlin/com/varabyte/kobweb/intellij/startup/DiscoverKobwebProjectsProjectActivity.kt
@@ -1,0 +1,188 @@
+package com.varabyte.kobweb.intellij.startup
+
+import com.intellij.openapi.components.service
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.module.ModuleManager
+import com.intellij.openapi.project.ModuleListener
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.roots.ModuleRootEvent
+import com.intellij.openapi.roots.ModuleRootListener
+import com.intellij.openapi.roots.ModuleRootManager
+import com.intellij.openapi.startup.ProjectActivity
+import com.intellij.util.Function
+import com.varabyte.kobweb.intellij.project.KobwebProject
+import com.varabyte.kobweb.intellij.services.project.KobwebProjectCacheService
+import org.gradle.tooling.GradleConnector
+import org.gradle.tooling.model.GradleProject
+import org.jetbrains.kotlin.idea.base.util.isGradleModule
+import org.jetbrains.plugins.gradle.util.GradleUtil
+import java.io.File
+
+// Constants useful for identifying external dependencies as Kobweb projects
+private const val KOBWEB_METADATA_ROOT = "META-INF/kobweb"
+private val KOBWEB_METADATA_IDENTIFIERS_LIBRARY = listOf(
+    "$KOBWEB_METADATA_ROOT/library.json",
+    // Legacy ways to identify a library, before library.json was introduced
+    // We can remove these after a few months and/or when Kobweb hits 1.0
+    "$KOBWEB_METADATA_ROOT/frontend.json",
+    "$KOBWEB_METADATA_ROOT/backend.json",
+)
+private const val KOBWEB_METADATA_IDENTIFIER_WORKER = "$KOBWEB_METADATA_ROOT/worker.json"
+
+/**
+ * On startup, run through all modules and dependencies, discovering which represent Kobweb projects.
+ */
+class DiscoverKobwebProjectsProjectActivity : ProjectActivity {
+    // We originally were hoping to query a Gradle project's list of plugins to see which sort of Kobweb plugin it used;
+    // however, the Gradle tooling API doesn't support this. So it's a little bit hacky, but we will just search for
+    // tasks that we know are unique to each plugin type and use that to identify it. This is slightly dangerous because
+    // there's no guarantee we won't delete or rename these tasks in the future, but if that happens, then we'll get
+    // bug reports that the Kobweb plugin stopped working in those modules, which is not fatal.
+    private object KobwebTaskNames {
+        const val APPLICATION = "kobwebStart"
+        const val LIBRARY =
+            "kobwebGenerateLibraryMetadata" // NOTE: Older versions may use "kobwebGenerateLibraryMetadataTask"
+        const val WORKER =
+            "kobwebGenerateWorkerMetadata" // NOTE: Older versions may use "kobwebGenerateWorkerMetadataTask"
+    }
+
+    private fun GradleProject.findKobwebProjectType(): KobwebProject.Type? {
+        return tasks.asSequence()
+            .mapNotNull {
+                when {
+                    it.name == KobwebTaskNames.APPLICATION -> KobwebProject.Type.Application
+                    it.name.startsWith(KobwebTaskNames.LIBRARY) -> KobwebProject.Type.Library
+                    it.name.startsWith(KobwebTaskNames.WORKER) -> KobwebProject.Type.Worker
+                    else -> null
+                }
+            }
+            .firstOrNull()
+    }
+
+    private fun Project.queryGradleForKobwebProjects(): Set<KobwebProject> {
+        val kobwebProjects = mutableSetOf<KobwebProject>()
+
+        basePath?.let { File(it) }?.let { projectRoot ->
+            val connection = GradleConnector.newConnector()
+                .forProjectDirectory(projectRoot)
+                .connect()
+
+            val allProjects = mutableListOf<GradleProject>()
+            connection.getModel(GradleProject::class.java)?.let { rootProject ->
+                allProjects.add(rootProject)
+                allProjects.addAll(rootProject.children)
+            }
+
+            allProjects.forEach { gradleProject ->
+                gradleProject.findKobwebProjectType()?.let { kobwebProjectType ->
+                    GradleUtil.findGradleModule(this, gradleProject.projectDirectory.path)?.let { gradleModule ->
+                        kobwebProjects.add(
+                            KobwebProject(
+                                gradleProject.path,
+                                kobwebProjectType,
+                                KobwebProject.Source.Local(gradleModule)
+                            )
+                        )
+                    }
+                }
+            }
+        }
+        return kobwebProjects
+    }
+
+    private fun Project.queryDependenciesForKobwebProjects(): Set<KobwebProject> {
+        val kobwebProjects = mutableSetOf<KobwebProject>()
+
+        val moduleManager = ModuleManager.getInstance(this)
+        moduleManager.modules.forEach { module ->
+            val moduleRootManager = ModuleRootManager.getInstance(module)
+            moduleRootManager.orderEntries().forEachLibrary { library ->
+                library?.let { lib ->
+                    lib
+                        .getFiles(com.intellij.openapi.roots.OrderRootType.CLASSES)
+                        .filter { it.extension == "klib" }
+                        .forEach { klib ->
+                            val kobwebProjectType = when {
+                                KOBWEB_METADATA_IDENTIFIERS_LIBRARY.any { klib.findFileByRelativePath(it) != null } -> {
+                                    KobwebProject.Type.Library
+                                }
+
+                                klib.findFileByRelativePath(KOBWEB_METADATA_IDENTIFIER_WORKER) != null -> {
+                                    KobwebProject.Type.Worker
+                                }
+
+                                else -> null
+                            }
+
+                            if (kobwebProjectType != null) {
+                                kobwebProjects.add(
+                                    KobwebProject(
+                                        klib.name,
+                                        kobwebProjectType,
+                                        KobwebProject.Source.External(klib)
+                                    )
+                                )
+                            }
+
+                        }
+                }
+                true // Keep iterating
+            }
+        }
+
+        return kobwebProjects
+    }
+
+    inner class RefreshKobwebProjectsModuleListener : ModuleListener {
+        private fun Project.refreshKobwebProjects() {
+            val kobwebProjects = service<KobwebProjectCacheService>()
+            kobwebProjects.removeIf { it.source is KobwebProject.Source.Local }
+
+            kobwebProjects.addAll(queryGradleForKobwebProjects())
+        }
+
+        override fun modulesAdded(project: Project, modules: MutableList<out Module>) {
+            if (modules.any { it.isGradleModule }) {
+                project.refreshKobwebProjects()
+            }
+        }
+
+        override fun moduleRemoved(project: Project, module: Module) {
+            if (project.service<KobwebProjectCacheService>()
+                    .any { it.source is KobwebProject.Source.Local && it.source.module === module }
+            ) {
+                project.refreshKobwebProjects()
+            }
+        }
+
+        override fun modulesRenamed(
+            project: Project,
+            modules: MutableList<out Module>,
+            oldNameProvider: Function<in Module, String>
+        ) {
+            val kobwebProjects = project.service<KobwebProjectCacheService>()
+            if (modules.any { module -> kobwebProjects.any { it.name == module.name } }) {
+                project.refreshKobwebProjects()
+            }
+        }
+    }
+
+    inner class RefreshKobwebProjectsModuleRootListener : ModuleRootListener {
+        override fun rootsChanged(event: ModuleRootEvent) {
+            val kobwebProjects = event.project.service<KobwebProjectCacheService>()
+            kobwebProjects.removeIf { it.source is KobwebProject.Source.External }
+
+            kobwebProjects.addAll(event.project.queryDependenciesForKobwebProjects())
+        }
+    }
+
+    override suspend fun execute(project: Project) {
+        val kobwebProjects = project.service<KobwebProjectCacheService>()
+
+        kobwebProjects.addAll(project.queryGradleForKobwebProjects())
+        project.messageBus.connect().subscribe(ModuleListener.TOPIC, RefreshKobwebProjectsModuleListener())
+
+        kobwebProjects.addAll(project.queryDependenciesForKobwebProjects())
+        project.messageBus.connect().subscribe(ModuleRootListener.TOPIC, RefreshKobwebProjectsModuleRootListener())
+    }
+}

--- a/src/main/kotlin/com/varabyte/kobweb/intellij/util/kobweb/KobwebUtils.kt
+++ b/src/main/kotlin/com/varabyte/kobweb/intellij/util/kobweb/KobwebUtils.kt
@@ -1,0 +1,38 @@
+package com.varabyte.kobweb.intellij.util.kobweb
+
+import com.intellij.psi.PsiElement
+import com.varabyte.kobweb.intellij.project.KobwebProject
+import com.varabyte.kobweb.intellij.util.kobweb.project.findKobwebProject
+import org.jetbrains.kotlin.psi.KtFile
+
+private fun PsiElement.isInKobwebContext(test: (KobwebProject) -> Boolean): Boolean {
+    return findKobwebProject()?.let { return test(it) } ?: false
+}
+
+private fun PsiElement.isInKobwebSource(): Boolean {
+    return (this.containingFile as? KtFile)?.packageFqName?.asString()?.startsWith("com.varabyte.kobweb") ?: false
+}
+
+/**
+ * Useful test to see if a read-only Kobweb Plugin action (like an inspection) should run here.
+ *
+ * @param limitTo The [KobwebProject] types to limit this action to. By default, restricted to presentation types (that
+ *   is, the parts of Kobweb that interact with the DOM). This default was chosen because this is by far the most
+ *   common case, the kind of code that most people associate with Kobweb.
+ *
+ * @param excludeKobwebSource If true, then disable this action if the user is navigating around Kobweb source code.
+ *   By default, this is false, so unless this is explicitly set, this extension point will be active inside Kobweb
+ *   source.
+ */
+fun PsiElement.isInKobwebReadContext(limitTo: Set<KobwebProject.Type> = KobwebProject.Types.Framework, excludeKobwebSource: Boolean = false): Boolean {
+    return isInKobwebContext { it.type in limitTo } || (!excludeKobwebSource && isInKobwebSource())
+}
+
+/**
+ * Useful test to see if a writing Kobweb Plugin action (like a refactor) should be allowed to run here.
+ *
+ * @param limitTo See the docs for [isInKobwebReadContext] for more info.
+ */
+fun PsiElement.isInKobwebWriteContext(limitTo: Set<KobwebProject.Type> = KobwebProject.Types.Framework): Boolean {
+    return isInKobwebContext { it.type in limitTo && it.source is KobwebProject.Source.Local }
+}

--- a/src/main/kotlin/com/varabyte/kobweb/intellij/util/kobweb/project/KobwebProjectUtils.kt
+++ b/src/main/kotlin/com/varabyte/kobweb/intellij/util/kobweb/project/KobwebProjectUtils.kt
@@ -1,0 +1,68 @@
+package com.varabyte.kobweb.intellij.util.kobweb.project
+
+import com.intellij.openapi.components.service
+import com.intellij.openapi.module.ModuleUtil
+import com.intellij.openapi.vfs.JarFileSystem
+import com.intellij.openapi.vfs.VfsUtilCore
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiElement
+import com.varabyte.kobweb.intellij.project.KobwebProject
+import com.varabyte.kobweb.intellij.services.project.KobwebProjectCacheService
+import org.jetbrains.kotlin.idea.core.util.toVirtualFile
+import org.jetbrains.plugins.gradle.util.GradleUtil
+
+/**
+ * Given a PSI element that represents a piece of code inside a Kotlin dependency, fetch its containing klib.
+ *
+ * This will work even if the PSI element is contained inside a sources jar, assuming it is a sibling to the klib.
+ */
+private val PsiElement.containingKlib: VirtualFile?
+    get() {
+        /**
+         * Given a virtual file that points at a sources jar, return its sibling klib file.
+         */
+        fun VirtualFile.sourcesJarToKlib(): VirtualFile? {
+            // The virtual file representing the jar is rooted at the jar itself; jar.parent would return null.
+            // Therefore, we have to escape out of the virtual file ecosystem and into the IO file system to escape. Once
+            // out, it's easy to find a sibling file because we can access the parent directory.
+            val ioFile = VfsUtilCore.virtualToIoFile(this)
+            val nameWithoutExtension = ioFile.nameWithoutExtension.removeSuffix("-sources")
+
+            val klibFile = ioFile.parentFile.resolve("$nameWithoutExtension.klib")
+            return klibFile.toVirtualFile()?.let { JarFileSystem.getInstance().getJarRootForLocalFile(it) }
+        }
+
+        var currFile: VirtualFile? = this.containingFile.virtualFile
+        while (currFile != null) {
+            if (currFile.extension == "jar") {
+                currFile = currFile.sourcesJarToKlib()
+                break
+            } else if (currFile.extension == "klib") {
+                break
+            }
+
+            currFile = currFile.parent
+        }
+
+        return currFile
+    }
+
+/**
+ * Returns the Kobweb project associated with the owning context of this element, or null if none is found.
+ *
+ * Kobweb project information can be associated with both local modules and third-party artifacts (e.g. maven
+ * dependencies).
+ */
+fun PsiElement.findKobwebProject(): KobwebProject? {
+    val kobwebProjects = project.service<KobwebProjectCacheService>()
+    return ModuleUtil.findModuleForPsiElement(this)?.let { elementModule ->
+        // Note that this module is likely a specific source submodule of the module we want (the one associated with
+        // the Gradle build script). That is, we are probably getting "app.site.jsMain" when we want "app.site"
+        @Suppress("UnstableApiUsage") // "findGradleModuleData" has been experimental for 5 years...
+        GradleUtil.findGradleModuleData(elementModule)?.let { moduleDataNode ->
+            GradleUtil.findGradleModule(this.project, moduleDataNode.data)?.let { gradleModule ->
+                kobwebProjects[gradleModule]
+            }
+        }
+    } ?: this.containingKlib?.let { kobwebProjects[it] }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -25,6 +25,12 @@
     <!-- Extension points defined by the plugin.
          Read more: https://plugins.jetbrains.com/docs/intellij/plugin-extension-points.html -->
     <extensions defaultExtensionNs="com.intellij">
+        <postStartupActivity implementation="com.varabyte.kobweb.intellij.startup.DiscoverKobwebProjectsProjectActivity" />
+
+        <projectService
+                serviceInterface="com.varabyte.kobweb.intellij.services.project.KobwebProjectCacheService"
+                serviceImplementation="com.varabyte.kobweb.intellij.services.project.KobwebProjectCacheServiceImpl"/>
+
         <lang.inspectionSuppressor language="kotlin" implementationClass="com.varabyte.kobweb.intellij.inspections.FunctionNameInspectionSuppressor"/>
         <lang.inspectionSuppressor language="kotlin" implementationClass="com.varabyte.kobweb.intellij.inspections.UnusedInspectionSuppressor"/>
 


### PR DESCRIPTION
This works by adding a KobwebProject concept, which can detect if a module or artifact is a Kobweb application, library, or worker.

With this logic in place, we can add early abort steps to our actions to avoid running things if we don't need to.