### PR TITLE
We now persist Kobweb Model metadata across restarts

### DIFF
--- a/plugin/src/main/kotlin/com/varabyte/kobweb/intellij/notification/KobwebNotifier.kt
+++ b/plugin/src/main/kotlin/com/varabyte/kobweb/intellij/notification/KobwebNotifier.kt
@@ -1,0 +1,134 @@
+package com.varabyte.kobweb.intellij.notification
+
+import com.intellij.notification.Notification
+import com.intellij.notification.NotificationAction
+import com.intellij.notification.NotificationGroupManager
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.Project
+
+private val notificationGroup by lazy {
+    NotificationGroupManager.getInstance().getNotificationGroup("Kobweb")
+}
+
+/**
+ * A handle to a notification that provides some constrained operations on it.
+ */
+class KobwebNotificationHandle(private val notification: Notification) {
+    /**
+     * Manually expire the notification.
+     *
+     * This dismissed it and greys out any of its actions.
+     */
+    fun expire() {
+        notification.expire()
+    }
+}
+
+/**
+ * A convenience class for generating notifications tagged with the Kobweb group.
+ *
+ * You can either use a [Builder] to generate a notification (which you must then call [Builder.notify] on), or use
+ * one of the convenience [notify] methods.
+ *
+ * @see Notification
+ */
+class KobwebNotifier {
+    /**
+     * A builder class for creating notifications.
+     *
+     * You must call [notify] on the builder to actually display the notification.
+     *
+     * If you need to create two (or more) actions on a single notification, this is the preferred approach.
+     */
+    @Suppress("MemberVisibilityCanBePrivate")
+    class Builder(private val message: String) {
+        constructor(title: String, message: String) : this(message) {
+            title(title)
+        }
+
+        private class ActionData(val text: String, val action: () -> Unit)
+
+        private var title: String = ""
+        private var type: NotificationType = NotificationType.INFORMATION
+        private var actionDataList = mutableListOf<ActionData>()
+
+        fun title(title: String) = apply { this.title = title }
+
+        /**
+         * Register a clickable action associated with this notification.
+         *
+         * You can register multiple actions per notification.
+         *
+         * Once clicked, the action will be performed and the notification will be dismissed.
+         */
+        fun addAction(text: String, action: () -> Unit) =
+            apply { actionDataList.add(ActionData(text, action)) }
+
+        fun type(type: NotificationType) = apply { this.type = type }
+
+        fun notify(project: Project): KobwebNotificationHandle {
+            val notification = notificationGroup.createNotification(
+                title,
+                message,
+                type,
+            )
+
+            actionDataList.forEach { actionData ->
+                notification.addAction(object : NotificationAction(actionData.text) {
+                    override fun actionPerformed(e: AnActionEvent, notification: Notification) {
+                        actionData.action()
+                        notification.expire()
+                    }
+                })
+            }
+
+            notification.notify(project)
+            return KobwebNotificationHandle(notification)
+        }
+    }
+
+    @Suppress("unused")
+    companion object {
+        fun notify(
+            project: Project,
+            title: String,
+            message: String,
+            type: NotificationType? = null
+        ): KobwebNotificationHandle {
+            return Builder(title, message)
+                .apply { type?.let { type(it) } }
+                .notify(project)
+        }
+
+        fun notify(project: Project, message: String, type: NotificationType? = null): KobwebNotificationHandle {
+            return Builder(message)
+                .apply { type?.let { type(it) } }
+                .notify(project)
+        }
+
+        fun notify(
+            project: Project,
+            title: String,
+            message: String,
+            actionText: String,
+            type: NotificationType? = null,
+            action: () -> Unit
+        ): KobwebNotificationHandle {
+            return Builder(title, message)
+                .apply { type?.let { type(it) } }
+                .addAction(actionText, action)
+                .notify(project)
+        }
+
+        fun notify(
+            project: Project,
+            message: String,
+            actionText: String,
+            type: NotificationType? = null,
+            action: () -> Unit
+        ): KobwebNotificationHandle {
+            return notify(project, title = "", message, actionText, type, action)
+        }
+    }
+}

--- a/plugin/src/main/kotlin/com/varabyte/kobweb/intellij/persist/project/KobwebModulesPersistentStateComponent.kt
+++ b/plugin/src/main/kotlin/com/varabyte/kobweb/intellij/persist/project/KobwebModulesPersistentStateComponent.kt
@@ -1,0 +1,124 @@
+package com.varabyte.kobweb.intellij.persist.project
+
+import com.intellij.openapi.components.*
+import com.intellij.openapi.module.Module
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.modules
+import com.intellij.util.xmlb.annotations.XMap
+import com.varabyte.kobweb.intellij.model.KobwebModel
+import com.varabyte.kobweb.intellij.model.KobwebProjectType
+
+/**
+ * A [BaseState] wrapper around a [KobwebModel] so it plays nicer with IntelliJ's persistence system.
+ */
+class KobwebModelState : BaseState() {
+    companion object {
+        fun from(kobwebModel: KobwebModel): KobwebModelState {
+            return KobwebModelState().apply {
+                projectType = kobwebModel.projectType
+            }
+        }
+    }
+
+    var projectType by enum<KobwebProjectType>()
+}
+
+fun KobwebModelState.intoKobwebModel(): KobwebModel? {
+    val projectType = this.projectType ?: return null
+    return object : KobwebModel {
+        override val projectType = projectType
+    }
+}
+
+/**
+ * A persistable class which represents a mapping of IntelliJ modules to their KobwebModel metadata, if present.
+ */
+class KobwebModulesState : BaseState() {
+    companion object {
+        // NOTE: If you increment this version, then the user will get a request to resync their project to rebuild
+        // this state object. You should use it if you need it but consider it carefully.
+        const val VERSION = 1
+    }
+
+    /**
+     * A mapping of the module's name to state describing the Kobweb model it is associated with.
+     */
+    @get:XMap
+    val modelMap by map<String, KobwebModelState>()
+    var isInitialized by property(false)
+    var version by property(0)
+}
+
+/**
+ * Persisted metadata for which modules have Kobweb models associated with them.
+ *
+ * Calls should be sure to call [initialize] before registering any models. In this way, the caller will be able to
+ * distinguish between a fresh state and a state built for a project that simply doesn't have any Kobweb metadata in it
+ * (which is common if you installed the Kobweb plugin but naturally use the IDE for many other non-Kobweb projects).
+ */
+@Service(Service.Level.PROJECT)
+@State(
+    name = "KobwebModules",
+    storages = [Storage("kobwebModules.xml")]
+
+)
+class KobwebModulesPersistentStateComponent : SimplePersistentStateComponent<KobwebModulesState>(KobwebModulesState()) {
+    /**
+     * Return whether the current state is valid, which means that it represents real data from a previous sync.
+     *
+     * This can become invalid over time if [KobwebModulesState.VERSION] ever changes or if any of the paths to any of
+     * the modules can't be found.
+     */
+    fun isStateValid(project: Project) =
+        state.isInitialized && state.version == KobwebModulesState.VERSION && state.modelMap.all { (name, state) ->
+            project.moduleNamed(name) != null && state.intoKobwebModel() != null
+        }
+
+    /**
+     * Reset the state of this component to a fresh state.
+     *
+     * This will schedule the XML file for removal as a side effect.
+     *
+     * While a rare case, it could be useful to reset the state if you had a Kobweb dependency in your project, then
+     * removed it, and did a Gradle sync.
+     */
+    fun reset() {
+        loadState(KobwebModulesState())
+    }
+
+    /**
+     * Initialize this component's state, which you are expected to do before calling [addKobwebModel].
+     */
+    fun initialize() {
+        state.modelMap.clear()
+        state.isInitialized = true
+        state.version = KobwebModulesState.VERSION
+    }
+
+    private fun Project.moduleNamed(name: String): Module? {
+        return this.modules.firstOrNull { it.name == name }
+    }
+
+    /**
+     * Register a [KobwebModel] with this persistent state component.
+     *
+     * It is an error if you do this without first calling [initialize].
+     */
+    fun addKobwebModel(module: Module, kobwebModel: KobwebModel) {
+        check(state.isInitialized)
+        state.modelMap[module.name] = KobwebModelState.from(kobwebModel)
+    }
+
+    /**
+     * Returns an iterator that you can use to run over the mapping of all Kobweb modules in the project.
+     *
+     * Note that this iterator is empty if [isStateValid] returns false.
+     */
+    fun iterator(project: Project): Iterator<Map.Entry<Module, KobwebModel>> {
+        val sourceMap = state.modelMap.takeIf { isStateValid(project) } ?: emptyMap()
+        return sourceMap.map { (moduleName, kobwebModelState) ->
+            // Guaranteed non-null because of `isStateValid`
+            project.moduleNamed(moduleName)!! to kobwebModelState.intoKobwebModel()!!
+        }.toMap().iterator()
+    }
+}

--- a/plugin/src/main/kotlin/com/varabyte/kobweb/intellij/project/KobwebGradleProjectResolver.kt
+++ b/plugin/src/main/kotlin/com/varabyte/kobweb/intellij/project/KobwebGradleProjectResolver.kt
@@ -1,6 +1,5 @@
 package com.varabyte.kobweb.intellij.project
 
-import com.intellij.openapi.application.Application
 import com.intellij.openapi.diagnostic.LogLevel
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.externalSystem.model.DataNode
@@ -9,8 +8,6 @@ import com.intellij.openapi.externalSystem.model.project.ModuleData
 import com.intellij.openapi.externalSystem.model.project.ProjectData
 import com.intellij.openapi.externalSystem.util.ExternalSystemApiUtil
 import com.intellij.openapi.module.Module
-import com.intellij.openapi.project.Project
-import com.jetbrains.rd.util.AtomicInteger
 import com.varabyte.kobweb.intellij.model.KobwebModel
 import com.varabyte.kobweb.intellij.model.gradle.tooling.KobwebModelBuilderService
 import org.gradle.tooling.model.idea.IdeaModule
@@ -60,6 +57,14 @@ class KobwebGradleProjectResolver : AbstractProjectResolverExtension() {
         ideModule.createChild(Keys.KOBWEB_MODEL, kobwebModel)
         logger.info("Module \"${gradleModule.name}\" is a Kobweb module [${kobwebModel.projectType}]")
     }
+}
+
+fun Module.setKobwebModel(kobwebModel: KobwebModel) {
+    val modulePath = ExternalSystemApiUtil.getExternalProjectPath(this) ?: return
+    val project = this.project
+
+    val moduleNode = ExternalSystemApiUtil.findModuleNode(project, GradleConstants.SYSTEM_ID, modulePath)
+    moduleNode?.createChild(KobwebGradleProjectResolver.Keys.KOBWEB_MODEL, kobwebModel)
 }
 
 fun Module.findKobwebModel(): KobwebModel? {

--- a/plugin/src/main/kotlin/com/varabyte/kobweb/intellij/services/project/KobwebProjectCacheService.kt
+++ b/plugin/src/main/kotlin/com/varabyte/kobweb/intellij/services/project/KobwebProjectCacheService.kt
@@ -4,6 +4,7 @@ import com.intellij.openapi.module.Module
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.psi.PsiElement
 import com.varabyte.kobweb.intellij.project.KobwebProject
+import com.varabyte.kobweb.intellij.util.module.toGradleModule
 import com.varabyte.kobweb.intellij.util.psi.containingKlib
 import org.jetbrains.kotlin.idea.base.util.module
 import java.util.*
@@ -54,7 +55,7 @@ private class KobwebProjectCacheServiceImpl : KobwebProjectCacheService {
 
     // There are easily thousands of elements in a project, so it would be wasteful to store each one individually.
     // Instead, we return a container as broad as possible and store that.
-    private fun PsiElement.toElementContainer(): Any = module ?: containingKlib ?: containingFile
+    private fun PsiElement.toElementContainer(): Any = module?.toGradleModule() ?: containingKlib ?: containingFile
 
     override fun isMarkedNotKobweb(element: PsiElement): Boolean {
         return notKobwebProjects.contains(element.toElementContainer())

--- a/plugin/src/main/kotlin/com/varabyte/kobweb/intellij/startup/KobwebPostStartupProjectActivity.kt
+++ b/plugin/src/main/kotlin/com/varabyte/kobweb/intellij/startup/KobwebPostStartupProjectActivity.kt
@@ -1,17 +1,54 @@
 package com.varabyte.kobweb.intellij.startup
 
+import com.intellij.notification.NotificationType
+import com.intellij.openapi.actionSystem.*
+import com.intellij.openapi.actionSystem.ex.ActionUtil
+import com.intellij.openapi.actionSystem.ex.AnActionListener
 import com.intellij.openapi.components.service
+import com.intellij.openapi.externalSystem.action.RefreshAllExternalProjectsAction
 import com.intellij.openapi.externalSystem.service.project.manage.ProjectDataImportListener
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.modules
 import com.intellij.openapi.startup.ProjectActivity
+import com.varabyte.kobweb.intellij.notification.KobwebNotificationHandle
+import com.varabyte.kobweb.intellij.notification.KobwebNotifier
+import com.varabyte.kobweb.intellij.persist.project.KobwebModulesPersistentStateComponent
+import com.varabyte.kobweb.intellij.project.findKobwebModel
+import com.varabyte.kobweb.intellij.project.setKobwebModel
 import com.varabyte.kobweb.intellij.services.project.KobwebProjectCacheService
+import com.varabyte.kobweb.intellij.util.module.toGradleModule
+import com.varabyte.kobweb.intellij.util.project.hasAnyKobwebDependency
+
 
 /**
  * Actions to perform after the project has been loaded.
  */
 class KobwebPostStartupProjectActivity : ProjectActivity {
-    private class ImportListener(private val project: Project) : ProjectDataImportListener {
+    private class ImportListener(
+        private val project: Project,
+        private val syncRequestedNotification: KobwebNotificationHandle?
+    ) : ProjectDataImportListener {
+        override fun onImportStarted(projectPath: String?) {
+            // If an import is kicked off in an indirect way, we should still dismiss the sync popup.
+            syncRequestedNotification?.expire()
+        }
+
         override fun onImportFinished(projectPath: String?) {
+            val kobwebModels = project.service<KobwebModulesPersistentStateComponent>()
+            if (project.hasAnyKobwebDependency()) {
+                kobwebModels.initialize()
+                project.modules.forEach { module ->
+                    // Avoid adding models unnecessarily to nested modules (e.g. `jsMain`, `jvmMain`)
+                    if (module === module.toGradleModule()) {
+                        module.findKobwebModel()?.let { model ->
+                            kobwebModels.addKobwebModel(module, model)
+                        }
+                    }
+                }
+            } else {
+                kobwebModels.reset()
+            }
+
             // After an import / gradle sync, let's just clear the cache, which should get automatically rebuilt
             // as users interact with their code.
             project.service<KobwebProjectCacheService>().clear()
@@ -19,7 +56,46 @@ class KobwebPostStartupProjectActivity : ProjectActivity {
     }
 
     override suspend fun execute(project: Project) {
+        val kobwebModels = project.service<KobwebModulesPersistentStateComponent>()
+
+        // If any models are found persisted, it means we just loaded up after a restart. Let's set them directly here
+        // instead of requiring another sync.
+        kobwebModels.iterator(project).forEach { (module, model) -> module.setKobwebModel(model) }
+        // It's possible that if a user opens a project with some files already opened that they can get cached as non-
+        // Kobweb files. So to be safe, we clear the cache after setting the models.
+        project.service<KobwebProjectCacheService>().clear()
+
+        val refreshProjectAction = ActionManager.getInstance().getAction("ExternalSystem.RefreshAllProjects") as? RefreshAllExternalProjectsAction
+        val syncRequestedNotification = if (refreshProjectAction != null && !kobwebModels.isStateValid(project) && project.hasAnyKobwebDependency()) {
+            KobwebNotifier.notify(
+                project,
+                "The Kobweb plugin requires a one-time sync to enable functionality.",
+                "Sync Project",
+                NotificationType.WARNING
+            ) {
+                ActionUtil.invokeAction(refreshProjectAction, { dataId ->
+                    when {
+                        PlatformDataKeys.PROJECT.`is`(dataId) -> project
+                        else -> null
+                    }
+                }, ActionPlaces.NOTIFICATION, null, null)
+            }
+        } else null
+
         val messageBusConnection = project.messageBus.connect()
-        messageBusConnection.subscribe(ProjectDataImportListener.TOPIC, ImportListener(project))
+        messageBusConnection.subscribe(
+            ProjectDataImportListener.TOPIC,
+            ImportListener(project, syncRequestedNotification)
+        )
+
+        messageBusConnection.subscribe(AnActionListener.TOPIC, object : AnActionListener {
+            override fun beforeActionPerformed(action: AnAction, event: AnActionEvent) {
+                if (action === refreshProjectAction) {
+                    // Dismiss the sync popup no matter how the user executed the sync action, either directly through
+                    // the notification or by pressing the Gradle sync project button.
+                    syncRequestedNotification?.expire()
+                }
+            }
+        })
     }
 }

--- a/plugin/src/main/kotlin/com/varabyte/kobweb/intellij/util/module/ModuleExtensions.kt
+++ b/plugin/src/main/kotlin/com/varabyte/kobweb/intellij/util/module/ModuleExtensions.kt
@@ -1,0 +1,21 @@
+package com.varabyte.kobweb.intellij.util.module
+
+import com.intellij.openapi.module.Module
+import com.intellij.psi.PsiElement
+import org.jetbrains.plugins.gradle.util.GradleUtil
+
+/**
+ * Given an IntelliJ module, return the associated module that represents the root of a Gradle project.
+ *
+ * Often, a module you fetch for a [PsiElement] is the one associated with a source directory, but what we often
+ * actually want is its parent module. That is, instead of the module "app.site.jsMain" we want "app.site".
+ *
+ * If found, the module returned will be home to a Gradle build file, and you can be confident it represents the
+ * root of a Gradle project.
+ */
+fun Module.toGradleModule(): Module? {
+    @Suppress("UnstableApiUsage") // "findGradleModuleData" has been experimental for 5 years...
+    return GradleUtil.findGradleModuleData(this)?.let { moduleDataNode ->
+        GradleUtil.findGradleModule(this.project, moduleDataNode.data)
+    }
+}

--- a/plugin/src/main/kotlin/com/varabyte/kobweb/intellij/util/project/ProjectExtensions.kt
+++ b/plugin/src/main/kotlin/com/varabyte/kobweb/intellij/util/project/ProjectExtensions.kt
@@ -1,0 +1,28 @@
+package com.varabyte.kobweb.intellij.util.project
+
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.project.modules
+import com.intellij.openapi.project.rootManager
+import com.intellij.openapi.roots.LibraryOrderEntry
+import com.intellij.openapi.roots.ModuleOrderEntry
+
+/**
+ * A simple heuristic for checking if this project has code in it somewhere that depends on Kobweb.
+ *
+ * This is useful as users may install the Kobweb plugin for one or two of their projects, but we should stay out of the
+ * way in every other kind of project.
+ */
+fun Project.hasAnyKobwebDependency(): Boolean {
+    return this.modules.asSequence()
+        .flatMap { module -> module.rootManager.orderEntries.asSequence() }
+        .any { orderEntry ->
+            when (orderEntry) {
+                // Most projects will indicate a dependency on Kobweb via library coordinates, e.g. `com.varabyte.kobweb:core`
+                is LibraryOrderEntry -> orderEntry.libraryName.orEmpty().substringBefore(':') == "com.varabyte.kobweb"
+                // Very rare, but if a project depends on Kobweb source directly, that counts. This is essentially for
+                // the `kobweb/playground` project which devs use to test latest Kobweb on.
+                is ModuleOrderEntry -> orderEntry.moduleName.substringBefore('.') == "kobweb"
+                else -> false
+            }
+        }
+}

--- a/plugin/src/main/resources/META-INF/plugin.xml
+++ b/plugin/src/main/resources/META-INF/plugin.xml
@@ -37,6 +37,8 @@
         <lang.inspectionSuppressor language="kotlin" implementationClass="com.varabyte.kobweb.intellij.inspections.UnusedInspectionSuppressor"/>
 
         <colorProvider implementation="com.varabyte.kobweb.intellij.colors.KobwebColorProvider" />
+
+        <notificationGroup displayType="BALLOON" id="Kobweb" />
     </extensions>
 
     <extensions defaultExtensionNs="org.jetbrains.plugins.gradle">


### PR DESCRIPTION
We also show an informative pop-up to users to kickstart the process if we detect they haven't generated the persisted data yet. This should only show up on existing Kobweb projects after the user installs the plugin. If the project is not related to Kobweb, or if it is a Kobweb project opened for the first time, it should not show up.

The Kobweb plugin lifecycle at this point is:

* The Kobweb plugin looks for persisted data.
* If it can't find it, it asks the user to sync.
* A sync, when done, resolves kobweb models (as before). But now, those models are also now persisted.
* After a restart, the Kobweb plugin will detect the persisted data and use it.
* If the user ever does another Gradle sync, the persisted model data will automatically be updated.

There's also now logic which checks if the project has at least one Kobweb dependency. If not, we make sure we don't show users the pop-up. We also early abort before checking / putting stuff into the KobwebProject cache in that case, which should save memory and time for those projects.