### PR TITLE
Update libs.versions.toml

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,9 +2,9 @@
 kobweb-ide-plugin="0.1.0"
 intellij-plugin = "1.17.2"
 jetbrains-changelog = "2.2.0"
-kotlin = "1.9.21"
-kotlinx-serialization = "1.6.0"
-truthish = "0.6.5"
+kotlin = "1.9.23"
+kotlinx-serialization = "1.6.3"
+truthish = "1.0.1"
 
 [libraries]
 kotlinx-serialization-core = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinx-serialization" }


### PR DESCRIPTION
Update minor depedencies versions without any major versions/breaking changes

If you take a look at this [link](https://github.com/varabyte/truthish/releases/tag/v1.0.0)

> However, as nothing has significantly changed in the APIs for basically a year and I've been using Truthish in a bunch of projects no problem, I decided to bump the release up to 1.0.0.

So updating Truthish from `0.6.3` to the latest version won't break anything